### PR TITLE
Replace pg connection method to new convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ node server.js
 or connect to mainnet:
 
 ```
-env NEAR_NETWORK=mainnet node server.js
+INDEXER_CONNECTION_STRING=postgres://public_readonly:nearprotocol@testnet.db.explorer.indexer.near.dev/testnet_explorer node server.js
 ```

--- a/server.js
+++ b/server.js
@@ -5,16 +5,9 @@ const app = express()
 app.use(cors())
 
 const getIndexerConnection = async () => {
-  const network = process.env.NEAR_NETWORK || 'testnet'
-  const connection = new Pool({
-    user: 'public_readonly',
-    password: 'nearprotocol',
-    host: `${network}.db.explorer.indexer.near.dev`,
-    database: `${network}_explorer`,
-    port: 5432,
-  })
+  const connection = new Pool({ connectionString: process.env.INDEXER_CONNECTION_STRING })
   return connection
-};
+}
 
 app.get('/getRequestTxs', async (req, res) => {
   try {


### PR DESCRIPTION
This PR contains update on pg connection config where it now uses `connectionString` to establish initial connection against postgres DB. 

This change is mitigation from API endpoint outage happened on 1/08/2022 where existing implementation was using `public_readonly`. It has been informed that this is bad practice and instead, indexer team provided us with dedicated connectionString for multisafe app (both testnet and mainnet)


